### PR TITLE
Fix xmrig-cuda link to point to MoneroOcean repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Main reasons why this plugin is separated project is:
 
 ## Windows usage
 
-* [Download](https://github.com/xmrig/xmrig-cuda/releases) plugin, you must choose CUDA version, usually it recent version (CUDA 10.1), but builds with older CUDA version also provided, alternative you can build the plugin from source.
+* [Download](https://github.com/MoneroOcean/xmrig-cuda/releases) plugin, you must choose CUDA version, usually it recent version (CUDA 10.1), but builds with older CUDA version also provided, alternative you can build the plugin from source.
 * Place **`xmrig-cuda.dll`** and other dll files near to **`xmrig.exe`**.
 * Edit **`config.json`** to enable CUDA support.
 ```


### PR DESCRIPTION
The current cuda link goes to the xmrig repository and not the MoneroOcean repository. I believe this can cause compatibility issues.