### PR TITLE
Add info about GCC 9 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Main reasons why this plugin is separated project is:
 
 ## Windows usage
 
-* [Download](https://github.com/xmrig/xmrig-cuda/releases) plugin, you must choose CUDA version, usually it recent version (CUDA 10.1), but builds with older CUDA version also provided, alternative you can build the plugin from source.
+* [Download](https://github.com/xmrig/xmrig-cuda/releases) plugin, you must choose CUDA version, usually it recent version (CUDA 10.1), but builds with older CUDA version also provided, alternative you can build the plugin from source (requiring GCC 9).
 * Place **`xmrig-cuda.dll`** and other dll files near to **`xmrig.exe`**.
 * Edit **`config.json`** to enable CUDA support.
 ```


### PR DESCRIPTION
To compile `xmrig-cuda`, the user needs to compile using GCC 9, this PR simply adds that info in the `README.md`